### PR TITLE
hotfix function elemento vacío

### DIFF
--- a/js/helpers/function.js
+++ b/js/helpers/function.js
@@ -117,6 +117,7 @@ function vistaModal(id) {
 
 function elementoVacio(dato) {
     (dato === undefined) ? dato = "": dato;
+    return dato;
 }
 
 /**


### PR DESCRIPTION
Se repara la function elemento vacío que no retornaba los datos después de comparar