### PR TITLE
footer siempre abajo, card no tapan titulo

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,18 +1,19 @@
 html{
-    height: 100%;
+    min-height: 100%;
+    position: relative;
 }
 
-body{
+/* body{
     
     display: flex;
     flex-direction: column;
     height: 100%;
-}
+} */
 
 #imprimir {
     position: fixed;
     bottom: 10%;
-    right: 1%;
+    right: 5%;
 }
 
 /*Edicion del Navbar*/

--- a/index.html
+++ b/index.html
@@ -75,7 +75,6 @@
         <div class="row">
             <div class="col">
                 <div class="p-5"></div>
-                <div class="p-5"></div>
             </div>
         </div>
     </div>

--- a/js/components/footer.js
+++ b/js/components/footer.js
@@ -15,8 +15,8 @@ class Footer extends HTMLElement {
           justify-content: space-between;
           align-items: center;
           width: 100%;
-          position: relative;
-          bottom: -149%;
+          position:absolute;
+          bottom: 0;
           line-height: 120%;
         }
           

--- a/view/productos/productos.html
+++ b/view/productos/productos.html
@@ -152,14 +152,7 @@
                 </tbody>
             </table>
         </div>
-
-        <div class="row">
-            <div class="col">
-                <div class="p-1"></div>
-            </div>
-        </div>
-
-
+        <div class="p-5"></div>
     </div>
 
 


### PR DESCRIPTION
correcciones al css y html para asegurar que el footer siempre este abajo en el final de la pagina, además de encuadrar bien el elemento de titulo principal que en algunos celulares era tapado por los botones