### PR TITLE
renombramiento del repositorio y de la app

### DIFF
--- a/js/helpers/function.js
+++ b/js/helpers/function.js
@@ -385,7 +385,7 @@ function redireccionamiento() {
     if (origin === "http://127.0.0.1:5500") {
         url = "";
     } else {
-        url = "invapp";
+        url = "/invapp";
     }
 
     return url

--- a/js/helpers/function.js
+++ b/js/helpers/function.js
@@ -385,7 +385,7 @@ function redireccionamiento() {
     if (origin === "http://127.0.0.1:5500") {
         url = "";
     } else {
-        url = "";
+        url = "invapp";
     }
 
     return url


### PR DESCRIPTION
Para mantener la consistencia se renombra el repositorio de WebStore a InvApp que es el nombre que se eligió para la aplicación  